### PR TITLE
Update tag

### DIFF
--- a/src/LaravelPasswordlessLoginProvider.php
+++ b/src/LaravelPasswordlessLoginProvider.php
@@ -8,16 +8,16 @@ class LaravelPasswordlessLoginProvider extends ServiceProvider
 {
     public function boot()
     {
-        $this->loadRoutesFrom(__DIR__.'/routes.php');
+        $this->loadRoutesFrom(__DIR__ . '/routes.php');
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'../config/config.php', config_path('laravel-passwordless-login.php'),
-            ], 'config');
+                __DIR__ . '../config/config.php', config_path('laravel-passwordless-login.php'),
+            ], 'passwordless-login-config');
         }
     }
 
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'laravel-passwordless-login');
+        $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'laravel-passwordless-login');
     }
 }

--- a/src/LaravelPasswordlessLoginProvider.php
+++ b/src/LaravelPasswordlessLoginProvider.php
@@ -8,16 +8,16 @@ class LaravelPasswordlessLoginProvider extends ServiceProvider
 {
     public function boot()
     {
-        $this->loadRoutesFrom(__DIR__ . '/routes.php');
+        $this->loadRoutesFrom(__DIR__.'/routes.php');
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__ . '../config/config.php', config_path('laravel-passwordless-login.php'),
+                __DIR__.'../config/config.php', config_path('laravel-passwordless-login.php'),
             ], 'passwordless-login-config');
         }
     }
 
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'laravel-passwordless-login');
+        $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'laravel-passwordless-login');
     }
 }

--- a/src/LaravelPasswordlessLoginProvider.php
+++ b/src/LaravelPasswordlessLoginProvider.php
@@ -8,16 +8,16 @@ class LaravelPasswordlessLoginProvider extends ServiceProvider
 {
     public function boot()
     {
-        $this->loadRoutesFrom(__DIR__.'/routes.php');
+        $this->loadRoutesFrom(__DIR__ . '/routes.php');
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'../config/config.php', config_path('laravel-passwordless-login.php'),
+                __DIR__ . '../config/config.php', config_path('laravel-passwordless-login.php'),
             ], 'config');
         }
     }
 
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'laravel-passwordless-login');
+        $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'laravel-passwordless-login');
     }
 }

--- a/src/LaravelPasswordlessLoginProvider.php
+++ b/src/LaravelPasswordlessLoginProvider.php
@@ -12,7 +12,7 @@ class LaravelPasswordlessLoginProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__ . '../config/config.php', config_path('laravel-passwordless-login.php'),
-            ], 'config');
+            ], 'passwordless-login-config');
         }
     }
 


### PR DESCRIPTION
Currently if you run `php artisan vendor:publish` you get a generic config tag which no one is sure is pointing to which configuration :

![Screenshot from 2020-03-04 22-25-18](https://user-images.githubusercontent.com/12772919/75920146-796c3b00-5e67-11ea-8796-7d0e56756692.png)


**But after this PR its explicit which one it will be:**

![Screenshot from 2020-03-04 22-26-01](https://user-images.githubusercontent.com/12772919/75920212-99036380-5e67-11ea-9686-9cc2f213775d.png)
