### PR TITLE
fixed user instance

### DIFF
--- a/src/LoginUrl.php
+++ b/src/LoginUrl.php
@@ -2,9 +2,7 @@
 
 namespace Grosv\LaravelPasswordlessLogin;
 
-use Grosv\LaravelPasswordlessLogin\Models\User;
-use Illuminate\Auth\AuthenticationException;
-use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\URL;
 
 class LoginUrl
@@ -31,19 +29,10 @@ class LoginUrl
 
     public function generate()
     {
-        if ($this->isAuthenticatable()) {
-            return URL::temporarySignedRoute(
-                $this->route_name, $this->route_expires, ['uid' => $this->user->id]
-            );
-        }
-    }
-
-    private function isAuthenticatable()
-    {
-        if ($this->user instanceof Authenticatable) {
-            return true;
-        } else {
-            throw new AuthenticationException('The model you passed as a user is unauthenticatable');
-        }
+        return URL::temporarySignedRoute(
+            $this->route_name,
+            $this->route_expires,
+            ['uid' => $this->user->id]
+        );
     }
 }

--- a/src/PasswordlessLogin.php
+++ b/src/PasswordlessLogin.php
@@ -6,8 +6,8 @@ use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method \Grosv\LaravelPasswordlessLogin\PasswordlessLoginManager forUser(User $user)
- * @method string generate()
+ * @method static \Grosv\LaravelPasswordlessLogin\PasswordlessLoginManager forUser(User $user)
+ * @method static string generate()
  */
 class PasswordlessLogin extends Facade
 {


### PR DESCRIPTION
A fix to issue https://github.com/grosv/laravel-passwordless-login/issues/12

The reason was that the constructor was making use of the `package's default User` but it has to be custom. Instead i used the `Authenticatable (User)` and removed redundant type check since the constructor is gonna handle that