### PR TITLE
Use trait for auth

### DIFF
--- a/src/LaravelPasswordlessLoginController.php
+++ b/src/LaravelPasswordlessLoginController.php
@@ -39,17 +39,18 @@ class LaravelPasswordlessLoginController extends Controller
 
         $user = $user_model::find($request->uid);
 
-        $usesTrait = $this->passwordlessLoginService->usesTrait($user);
+        $guard =  $user->guard_name ?? config('laravel-passwordless-login.user_guard');
 
-        $guard = $usesTrait ? $user->getGuard() : config('laravel-passwordless-login.user_guard');
-        $rememberLogin = $usesTrait ? $user->shouldRememberLogin() : config('laravel-passwordless-login.remember_login');
-        $redirectUrl = $usesTrait ? $user->getRedirectUrl() : ($request->redirect_to ?: config('laravel-passwordless-login.redirect_on_success'));
+        $rememberLogin = $user->should_remember_login ?? config('laravel-passwordless-login.remember_login');
+        $redirectUrl = $user->redirect_url ?? ($request->redirect_to ?: config('laravel-passwordless-login.redirect_on_success'));
 
         Auth::guard($guard)->login($user, $rememberLogin);
 
         if ($user->password !== Auth::user()->password) {
             abort(401);
         }
+
+        return redirect($redirectUrl);
     }
 
     /**
@@ -59,7 +60,7 @@ class LaravelPasswordlessLoginController extends Controller
      */
     public function redirectTestRoute()
     {
-        return response()->noContent(204);
+        return response(Auth::user()->name, 200);
     }
 
     /**
@@ -69,6 +70,6 @@ class LaravelPasswordlessLoginController extends Controller
      */
     public function overrideTestRoute()
     {
-        return response()->noContent(200);
+        return response('Redirected ' . Auth::user()->name, 200);
     }
 }

--- a/src/LaravelPasswordlessLoginController.php
+++ b/src/LaravelPasswordlessLoginController.php
@@ -44,10 +44,11 @@ class LaravelPasswordlessLoginController extends Controller
         $rememberLogin = $usesTrait ? $user->shouldRememberLogin() : config('laravel-passwordless-login.remember_login');
         $redirectUrl = $usesTrait ? $user->getRedirectUrl() : ($request->redirect_to ?: config('laravel-passwordless-login.redirect_on_success'));
 
-        Auth::guard($guard)
-            ->login($user, $rememberLogin);
-
-        return redirect($redirectUrl);
+        if (Auth::guard($guard)->login($user, $rememberLogin)) {
+            return redirect($redirectUrl);
+        } else {
+            abort(401, 'Failed to authenticate');
+        }
     }
 
     /**

--- a/src/LaravelPasswordlessLoginController.php
+++ b/src/LaravelPasswordlessLoginController.php
@@ -46,9 +46,10 @@ class LaravelPasswordlessLoginController extends Controller
 
         Auth::guard($guard)->login($user, $rememberLogin);
 
-        if (Auth::guard($guard)->user())
-            return redirect($redirectUrl);
-        else abort(401);
+        abort_if(!Auth::guard($guard)->user(), 401);
+
+        return redirect($redirectUrl);
+
     }
 
     /**

--- a/src/LaravelPasswordlessLoginController.php
+++ b/src/LaravelPasswordlessLoginController.php
@@ -32,6 +32,7 @@ class LaravelPasswordlessLoginController extends Controller
      */
     public function login(Request $request)
     {
+
         abort_if(!$request->hasValidSignature(), 401);
 
         $user_model = $this->passwordlessLoginService->getUserClass($request->user_type);
@@ -44,10 +45,10 @@ class LaravelPasswordlessLoginController extends Controller
         $rememberLogin = $usesTrait ? $user->shouldRememberLogin() : config('laravel-passwordless-login.remember_login');
         $redirectUrl = $usesTrait ? $user->getRedirectUrl() : ($request->redirect_to ?: config('laravel-passwordless-login.redirect_on_success'));
 
-        if (Auth::guard($guard)->login($user, $rememberLogin)) {
-            return redirect($redirectUrl);
-        } else {
-            abort(401, 'Failed to authenticate');
+        Auth::guard($guard)->login($user, $rememberLogin);
+
+        if ($user->password !== Auth::user()->password) {
+            abort(401);
         }
     }
 

--- a/src/LaravelPasswordlessLoginController.php
+++ b/src/LaravelPasswordlessLoginController.php
@@ -39,18 +39,16 @@ class LaravelPasswordlessLoginController extends Controller
 
         $user = $user_model::find($request->uid);
 
-        $guard =  $user->guard_name ?? config('laravel-passwordless-login.user_guard');
+        $guard = $user->guard_name ?? config('laravel-passwordless-login.user_guard');
 
         $rememberLogin = $user->should_remember_login ?? config('laravel-passwordless-login.remember_login');
         $redirectUrl = $user->redirect_url ?? ($request->redirect_to ?: config('laravel-passwordless-login.redirect_on_success'));
 
         Auth::guard($guard)->login($user, $rememberLogin);
 
-        if ($user->password !== Auth::user()->password) {
-            abort(401);
-        }
-
-        return redirect($redirectUrl);
+        if (Auth::guard($guard)->user())
+            return redirect($redirectUrl);
+        else abort(401);
     }
 
     /**

--- a/src/LoginUrl.php
+++ b/src/LoginUrl.php
@@ -37,11 +37,7 @@ class LoginUrl
         $this->passwordlessLoginService = new PasswordlessLoginService();
 
 
-        if ($this->passwordlessLoginService->usesTrait($user)) {
-            $this->route_expires = $user->getLoginRouteExpiresIn();
-        } else {
-            $this->route_expires = now()->addMinutes(config('laravel-passwordless-login.login_route_expires'));
-        }
+        $this->route_expires = $this->user->route_expires ?? now()->addMinutes(config('laravel-passwordless-login.login_route_expires'));
 
         $this->route_name = config('laravel-passwordless-login.login_route_name');
     }

--- a/src/LoginUrl.php
+++ b/src/LoginUrl.php
@@ -2,10 +2,8 @@
 
 namespace Grosv\LaravelPasswordlessLogin;
 
-use Grosv\LaravelPasswordlessLogin\Traits\PasswordlessLogable;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\URL;
-use Illuminate\Support\Str;
 
 class LoginUrl
 {
@@ -38,11 +36,12 @@ class LoginUrl
 
         $this->passwordlessLoginService = new PasswordlessLoginService();
 
-        if ($this->passwordlessLoginService->usesTrait($user))
 
+        if ($this->passwordlessLoginService->usesTrait($user)) {
             $this->route_expires = $user->getLoginRouteExpiresIn();
-        else
+        } else {
             $this->route_expires = now()->addMinutes(config('laravel-passwordless-login.login_route_expires'));
+        }
 
         $this->route_name = config('laravel-passwordless-login.login_route_name');
     }
@@ -58,22 +57,10 @@ class LoginUrl
             $this->route_name,
             $this->route_expires,
             [
-                'uid' => $this->user->id,
-                'redirect_to' => $this->redirect_url,
-                'user_type' => $this->getFormattedUserClass()
+                'uid'           => $this->user->id,
+                'redirect_to'   => $this->redirect_url,
+                'user_type'     => $this->passwordlessLoginService->getFormattedUserClass($this->user),
             ]
         );
-    }
-
-    /**
-     * Converts the user class into a slug to use for the route.
-     *
-     * @return string
-     */
-    private function getFormattedUserClass(): string
-    {
-        $userClassName = get_class($this->user);
-        $formattedName = str_replace('\\', '-', $userClassName);
-        return Str::slug($formattedName);
     }
 }

--- a/src/Models/Models/User.php
+++ b/src/Models/Models/User.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Grosv\LaravelPasswordlessLogin\Models\Models;
+
+use Grosv\LaravelPasswordlessLogin\Traits\Passwordless;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class User extends Authenticatable
+{
+    use Passwordless;
+    protected $table = 'users';
+    protected $fillable = ['name', 'email', 'password', 'phone'];
+}

--- a/src/PasswordlessLoginManager.php
+++ b/src/PasswordlessLoginManager.php
@@ -31,6 +31,20 @@ class PasswordlessLoginManager
     }
 
     /**
+     * Sets redirect URL for the Facade.
+     *
+     * @param string $redirectUrl
+     *
+     * @return $this
+     */
+    public function setRedirectUrl(string $redirectUrl): self
+    {
+        $this->loginUrl->setRedirectUrl($redirectUrl);
+
+        return $this;
+    }
+
+    /**
      * This generates the URL.
      *
      * @return string signed login url

--- a/src/PasswordlessLoginService.php
+++ b/src/PasswordlessLoginService.php
@@ -2,7 +2,7 @@
 
 namespace Grosv\LaravelPasswordlessLogin;
 
-use Grosv\LaravelPasswordlessLogin\Traits\PasswordlessLogable;
+use Grosv\LaravelPasswordlessLogin\Traits\Passwordless;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Str;
 
@@ -51,6 +51,6 @@ class PasswordlessLoginService
     {
         $traits = class_uses($user, true);
 
-        return in_array(PasswordlessLogable::class, $traits);
+        return in_array(Passwordless::class, $traits);
     }
 }

--- a/src/PasswordlessLoginService.php
+++ b/src/PasswordlessLoginService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Grosv\LaravelPasswordlessLogin;
+
+use Grosv\LaravelPasswordlessLogin\Traits\PasswordlessLogable;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Str;
+
+/**
+ * Service class to keep the controller clean.
+ */
+class PasswordlessLoginService
+{
+    /**
+     * Converts a class slug into a full class name.
+     *
+     * @param string $classSlug
+     *
+     * @return string
+     */
+    public function getUserClass(string $classSlug)
+    {
+        $slashedName = str_replace('-', '\\', $classSlug);
+
+        return Str::title($slashedName);
+    }
+
+    /**
+     * Checks if this use class uses the PasswordlessLogable trait.
+     *
+     * @param User $user
+     * @return bool
+     */
+    public function usesTrait(User $user): bool
+    {
+        $traits = class_uses($user, true);
+
+        return in_array(PasswordlessLogable::class, $traits);
+    }
+}

--- a/src/PasswordlessLoginService.php
+++ b/src/PasswordlessLoginService.php
@@ -26,9 +26,25 @@ class PasswordlessLoginService
     }
 
     /**
+     * Converts the user class into a slug to use for the route.
+     *
+     * @param User $user
+     *
+     * @return string
+     */
+    public function getFormattedUserClass(User $user): string
+    {
+        $userClassName = get_class($user);
+        $formattedName = str_replace('\\', '-', $userClassName);
+
+        return Str::slug($formattedName);
+    }
+
+    /**
      * Checks if this use class uses the PasswordlessLogable trait.
      *
      * @param User $user
+     *
      * @return bool
      */
     public function usesTrait(User $user): bool

--- a/src/Traits/Passwordless.php
+++ b/src/Traits/Passwordless.php
@@ -5,14 +5,14 @@ namespace Grosv\LaravelPasswordlessLogin\Traits;
 /**
  * Logs in a user without a password.
  */
-trait PasswordlessLogable
+trait Passwordless
 {
     /**
      * Returns the guard set for this user.
      *
      * @return string
      */
-    public function getGuard(): string
+    public function getGuardNameAttribute(): string
     {
         return config('laravel-passwordless-login.user_guard');
     }
@@ -22,7 +22,7 @@ trait PasswordlessLogable
      *
      * @return bool
      */
-    public function shouldRememberLogin(): bool
+    public function shouldRememberLoginAttribute(): bool
     {
         return config('laravel-passwordless-login.remember_login');
     }
@@ -32,7 +32,7 @@ trait PasswordlessLogable
      *
      * @return int
      */
-    public function getLoginRouteExpiresIn(): int
+    public function getLoginRouteExpiresInAttribute(): int
     {
         return config('laravel-passwordless-login.login_route_expires');
     }
@@ -42,7 +42,7 @@ trait PasswordlessLogable
      *
      * @return string
      */
-    public function getRedirectUrl(): string
+    public function getRedirectUrlAttribute(): string
     {
         return config('laravel-passwordless-login.redirect_on_success');
     }

--- a/src/Traits/PasswordlessLogable.php
+++ b/src/Traits/PasswordlessLogable.php
@@ -28,26 +28,6 @@ trait PasswordlessLogable
     }
 
     /**
-     * Returns the login route.
-     *
-     * @return string
-     */
-    public function getLoginRoute(): string
-    {
-        return config('laravel-passwordless-login.login_route');
-    }
-
-    /**
-     * Returns the login route name.
-     *
-     * @return string
-     */
-    public function getLoginRouteName(): string
-    {
-        return config('laravel-passwordless-login.login_route_name');
-    }
-
-    /**
      * Returns the number of minutes the route will expire in from the current time.
      *
      * @return int

--- a/src/Traits/PasswordlessLogable.php
+++ b/src/Traits/PasswordlessLogable.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Grosv\LaravelPasswordlessLogin\Traits;
+
+/**
+ * Logs in a user without a password.
+ */
+trait PasswordlessLogable
+{
+    /**
+     * Sets the guard of the logging user.
+     *
+     * Default is "web"
+     *
+     * @var string
+     */
+    protected $guard;
+
+    /**
+     * Sets whether or not to remember the logged in user.
+     *
+     * Default is "false"
+     *
+     * @var bool
+     */
+    protected $rememberLogin;
+
+    /**
+     * The url to be used for magic passwordless login.
+     *
+     * Default is "/magic-login"
+     *
+     * @var string
+     */
+    protected $loginRoute;
+
+    /**
+     * The time when the signed login route is valid in minutes.
+     *
+     * Default is 30
+     *
+     * @var int
+     */
+    protected $loginRouteExpires;
+
+    /**
+     * The url to redirect to if a login is successful.
+     *
+     * Default is "/"
+     *
+     * @var string
+     */
+    protected $redirectUrl;
+
+    /**
+     * Returns the guard set for this user.
+     *
+     * @return string
+     */
+    public function getGuard(): string
+    {
+        return $this->guard ?? config('laravel-passwordless-login.user_guard');
+    }
+
+    /**
+     * Whether a user should be remembered on login.
+     *
+     * @return bool
+     */
+    public function shouldRememberLogin(): bool
+    {
+        return $this->rememberLogin ?? config('laravel-passwordless-login.remember_login');
+    }
+
+    /**
+     * Returns the login route.
+     *
+     * @return string
+     */
+    public function getLoginRoute(): string
+    {
+        return $this->loginRoute ?? config('laravel-passwordless-login.login_route');
+    }
+
+    /**
+     * Returns the number of minutes the route will expire in from the current time.
+     *
+     * @return int
+     */
+    public function getLoginRouteExpiresIn(): int
+    {
+        return $this->loginRouteExpires ?? config('laravel-passwordless-login.login_route_expires');
+    }
+
+    /**
+     * Returns the url to redirect to on successful login.
+     *
+     * @return string
+     */
+    public function getRedirectUrl() : string
+    {
+        return $this->redirectUrl ?? config('laravel-passwordless-login.redirect_on_success');
+    }
+}

--- a/src/Traits/PasswordlessLogable.php
+++ b/src/Traits/PasswordlessLogable.php
@@ -8,58 +8,13 @@ namespace Grosv\LaravelPasswordlessLogin\Traits;
 trait PasswordlessLogable
 {
     /**
-     * Sets the guard of the logging user.
-     *
-     * Default is "web"
-     *
-     * @var string
-     */
-    protected $guard;
-
-    /**
-     * Sets whether or not to remember the logged in user.
-     *
-     * Default is "false"
-     *
-     * @var bool
-     */
-    protected $rememberLogin;
-
-    /**
-     * The url to be used for magic passwordless login.
-     *
-     * Default is "/magic-login"
-     *
-     * @var string
-     */
-    protected $loginRoute;
-
-    /**
-     * The time when the signed login route is valid in minutes.
-     *
-     * Default is 30
-     *
-     * @var int
-     */
-    protected $loginRouteExpires;
-
-    /**
-     * The url to redirect to if a login is successful.
-     *
-     * Default is "/"
-     *
-     * @var string
-     */
-    protected $redirectUrl;
-
-    /**
      * Returns the guard set for this user.
      *
      * @return string
      */
     public function getGuard(): string
     {
-        return $this->guard ?? config('laravel-passwordless-login.user_guard');
+        return config('laravel-passwordless-login.user_guard');
     }
 
     /**
@@ -69,7 +24,7 @@ trait PasswordlessLogable
      */
     public function shouldRememberLogin(): bool
     {
-        return $this->rememberLogin ?? config('laravel-passwordless-login.remember_login');
+        return config('laravel-passwordless-login.remember_login');
     }
 
     /**
@@ -79,7 +34,17 @@ trait PasswordlessLogable
      */
     public function getLoginRoute(): string
     {
-        return $this->loginRoute ?? config('laravel-passwordless-login.login_route');
+        return config('laravel-passwordless-login.login_route');
+    }
+
+    /**
+     * Returns the login route name.
+     *
+     * @return string
+     */
+    public function getLoginRouteName(): string
+    {
+        return config('laravel-passwordless-login.login_route_name');
     }
 
     /**
@@ -89,7 +54,7 @@ trait PasswordlessLogable
      */
     public function getLoginRouteExpiresIn(): int
     {
-        return $this->loginRouteExpires ?? config('laravel-passwordless-login.login_route_expires');
+        return config('laravel-passwordless-login.login_route_expires');
     }
 
     /**
@@ -97,8 +62,8 @@ trait PasswordlessLogable
      *
      * @return string
      */
-    public function getRedirectUrl() : string
+    public function getRedirectUrl(): string
     {
-        return $this->redirectUrl ?? config('laravel-passwordless-login.redirect_on_success');
+        return config('laravel-passwordless-login.redirect_on_success');
     }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -8,5 +8,5 @@ Route::get(
     [LaravelPasswordlessLoginController::class, 'login']
 )->name(config('laravel-passwordless-login.login_route_name'));
 
-Route::get('/laravel_passwordless_login_redirect_test_route', [LaravelPasswordlessLoginController::class, 'redirectTestRoute']);
-Route::get('/laravel_passwordless_login_redirect_overridden_route', [LaravelPasswordlessLoginController::class, 'overrideTestRoute']);
+Route::get('/laravel_passwordless_login_redirect_test_route', [LaravelPasswordlessLoginController::class, 'redirectTestRoute'])->middleware('web');
+Route::get('/laravel_passwordless_login_redirect_overridden_route', [LaravelPasswordlessLoginController::class, 'redirectTestRoute'])->middleware('web');

--- a/tests/SignedUrlTest.php
+++ b/tests/SignedUrlTest.php
@@ -60,7 +60,7 @@ class SignedUrlTest extends TestCase
         $this->assertGuest();
         $response = $this->followingRedirects()->get($this->url);
         $this->assertAuthenticatedAs($this->user);
-        $response->assertStatus(204);
+        $response->assertSuccessful();
         Auth::logout();
         $this->assertGuest();
     }

--- a/tests/SignedUrlTest.php
+++ b/tests/SignedUrlTest.php
@@ -5,6 +5,7 @@ namespace Tests;
 use Carbon\Carbon;
 use Faker\Factory as Faker;
 use Grosv\LaravelPasswordlessLogin\LoginUrl;
+use Grosv\LaravelPasswordlessLogin\Models\Models\User as ModelUser;
 use Grosv\LaravelPasswordlessLogin\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
@@ -30,6 +31,14 @@ class SignedUrlTest extends TestCase
             'remember_token'    => Str::random(10),
         ]);
 
+        $this->model_user = ModelUser::create([
+            'name'              => $faker->name,
+            'email'             => $faker->unique()->safeEmail,
+            'email_verified_at' => now(),
+            'password'          => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'remember_token'    => Str::random(10),
+        ]);
+
         Carbon::setTestNow();
 
         $generator = new LoginUrl($this->user);
@@ -40,11 +49,6 @@ class SignedUrlTest extends TestCase
         $this->uid = $uid;
     }
 
-    /** @test */
-    public function ed_knows_how_to_set_up_phpunit()
-    {
-        $this->assertTrue(true);
-    }
 
     /** @test */
     public function can_create_default_signed_login_url()
@@ -102,5 +106,19 @@ class SignedUrlTest extends TestCase
         $this->url = $generator->generate();
         $response = $this->followingRedirects()->get($this->url);
         $response->assertStatus(200);
+        $this->assertAuthenticatedAs($this->user);
+    }
+
+    /** @test */
+    public function allows_alternative_auth_model()
+    {
+        $generator = new LoginUrl($this->model_user);
+        $generator->setRedirectUrl('/laravel_passwordless_login_redirect_overridden_route');
+        $this->url = $generator->generate();
+        $response = $this->followingRedirects()->get($this->url);
+        $response->assertSuccessful();
+        $response->assertSee($this->model_user->name);
+        $this->assertAuthenticatedAs($this->model_user);
+
     }
 }


### PR DESCRIPTION
I seriously need some help guys. 

Generating the link is done but now I do not have the logic to pull a model type from the already generated link.

```
 public function login(Request $request)
    {
        abort_if(!$request->hasValidSignature(), 401);

        $user_model = config('laravel-passwordless-login.user_model');

        Auth::guard(config('laravel-passwordless-login.user_guard'))

        //more code there
    }
```
We used to fetch the user from the config file but now that we are migrating to a trait it means we opened room for more than one class (model).

The big question now is **How can we retrieve the current modal from the current request?** given the route is coming in with just the route life span and the model id