### PR TITLE
added login success callback

### DIFF
--- a/src/LaravelPasswordlessLoginController.php
+++ b/src/LaravelPasswordlessLoginController.php
@@ -48,7 +48,7 @@ class LaravelPasswordlessLoginController extends Controller
 
         abort_if(!Auth::guard($guard)->user(), 401);
 
-        return redirect($redirectUrl);
+        return $user->guard_name ? $user->onPasswordlessLoginSuccess($request) : redirect($redirectUrl);
     }
 
     /**

--- a/src/Traits/PasswordlessLogin.php
+++ b/src/Traits/PasswordlessLogin.php
@@ -49,8 +49,20 @@ trait PasswordlessLogin
         return config('laravel-passwordless-login.redirect_on_success');
     }
 
+
     public function createPasswordlessLoginLink()
     {
         return (new LoginUrl($this))->generate();
+    }
+    /**
+     * This is a callback called on a successful login.
+     *
+     * @param $request
+     *
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
+     */
+    public function onPasswordlessLoginSuccess($request)
+    {
+        return redirect($this->getRedirectUrlAttribute());
     }
 }


### PR DESCRIPTION
So this is coming in to issue https://github.com/grosv/laravel-passwordless-login/issues/20. 

I have added another method in the trait `PasswordlessLogin` named `onPasswordlessLoginSuccess($request)`;

By default this method if you do not override it in the model its gonna run a redirect but in the case you are using an API and you want generate a token or rather do some staff before returning a response the use. Example below:

In my `User` model i used `PasswordlessLogin` 
```
   public function onPasswordlessLoginSuccess($request)
   {
       return $this->createToken('my-token');
   }
```

Now instead of redirecting, a token is sent back in my case. I am sure there is more use cases