### PR TITLE
Use authenticatable instead of user model

### DIFF
--- a/src/LoginUrl.php
+++ b/src/LoginUrl.php
@@ -2,7 +2,7 @@
 
 namespace Grosv\LaravelPasswordlessLogin;
 
-use Illuminate\Foundation\Auth\User;
+use Illuminate\Contracts\Auth\Authenticatable as User;
 use Illuminate\Support\Facades\URL;
 
 class LoginUrl

--- a/src/PasswordlessLogin.php
+++ b/src/PasswordlessLogin.php
@@ -2,7 +2,7 @@
 
 namespace Grosv\LaravelPasswordlessLogin;
 
-use Illuminate\Foundation\Auth\User;
+use Illuminate\Contracts\Auth\Authenticatable as User;
 use Illuminate\Support\Facades\Facade;
 
 /**

--- a/src/PasswordlessLoginManager.php
+++ b/src/PasswordlessLoginManager.php
@@ -2,7 +2,7 @@
 
 namespace Grosv\LaravelPasswordlessLogin;
 
-use Illuminate\Foundation\Auth\User;
+use Illuminate\Contracts\Auth\Authenticatable as User;
 
 /**
  * The class used by \Grosv\LaravelPasswordlessLogin\PasswordlessLoginFacade.

--- a/src/PasswordlessLoginService.php
+++ b/src/PasswordlessLoginService.php
@@ -3,7 +3,7 @@
 namespace Grosv\LaravelPasswordlessLogin;
 
 use Grosv\LaravelPasswordlessLogin\Traits\PasswordlessLogin;
-use Illuminate\Foundation\Auth\User;
+use Illuminate\Contracts\Auth\Authenticatable as User;
 use Illuminate\Http\Request;
 
 /**


### PR DESCRIPTION
Using the authenticatable contract instead of the model allows developers to use this package with non-conventional authenticating models. For example, I am working on an application that for a specific set of users of the application they log in with only a code. This model does not extend the user model but does implement the authenticatable contract.