### PR TITLE
Check if custom url set, redirect to the url 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ class User extends Authenticatable
 
     public function getGuardNameAttribute(): string 
     {
-        return config('laravel-passwordless-login.remember_login');
+        return config('laravel-passwordless-login.user_guard');
     }
     
     public function shouldRememberLoginAttribute(): bool

--- a/src/Traits/PasswordlessLogin.php
+++ b/src/Traits/PasswordlessLogin.php
@@ -73,7 +73,7 @@ trait PasswordlessLogin
      */
     public function onPasswordlessLoginSuccess($request)
     {
-        return redirect($this->getRedirectUrlAttribute());
+        return ($request->has('redirect_to')) ? redirect($request->redirect_to) : redirect($this->getRedirectUrlAttribute());
     }
 
     /**


### PR DESCRIPTION
Fix custom Redirect URL not working if Guard Name attribute trait is set. Added checking to the ```onPasswordlessLoginSuccess()``` traits method to check if ```redirect_to``` attribute is define, then redirect to the custom url, else fall back to``` redirect_url``` defined in the user model.
Issue opened in #50 