### PR TITLE
Authenticable should use `getAuthIdentifier` not key name

### DIFF
--- a/src/LoginUrl.php
+++ b/src/LoginUrl.php
@@ -47,13 +47,11 @@ class LoginUrl
 
     public function generate()
     {
-        $idField = $this->user->getKeyName() ?? 'id';
-
         return URL::temporarySignedRoute(
             $this->route_name,
             $this->route_expires,
             [
-                'uid'           => $this->user->$idField,
+                'uid'           => $this->user->getAuthIdentifier(),
                 'redirect_to'   => $this->redirect_url,
                 'user_type'     => UserClass::toSlug(get_class($this->user)),
             ]


### PR DESCRIPTION
Continuing from https://github.com/grosv/laravel-passwordless-login/pull/47, we need to use `getAuthIdentifier` (from `Authenticable`) instead of the key name or `id` field.