### PR TITLE
Add guest middleware to login route

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Route;
 Route::get(
     config('laravel-passwordless-login.login_route').'/{uid}',
     [LaravelPasswordlessLoginController::class, 'login']
-)->middleware('web')->name(config('laravel-passwordless-login.login_route_name'));
+)->middleware(['web', 'guest'])->name(config('laravel-passwordless-login.login_route_name'));
 
 Route::get('/laravel_passwordless_login_redirect_test_route', [LaravelPasswordlessLoginController::class, 'redirectTestRoute'])->middleware('auth');
 Route::get('/laravel_passwordless_login_redirect_overridden_route', [LaravelPasswordlessLoginController::class, 'redirectTestRoute'])->middleware('auth');


### PR DESCRIPTION
Users tend to open their email and just click that login link they got a while ago again, although they are already logged in. 

Adding the `guest` middleware to the login route will redirect them to the proper route instead of the `401` or `404` page.