### PR TITLE
Update config.php to work with Carbon v3

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -8,7 +8,7 @@ return [
     'remember_login' => env('LPL_REMEMBER_LOGIN', false),
     'login_route' => env('LPL_LOGIN_ROUTE', '/magic-login'),
     'login_route_name' => env('LPL_LOGIN_ROUTE_NAME', 'magic-login'),
-    'login_route_expires' => env('LPL_LOGIN_ROUTE_EXPIRES', '30'),
+    'login_route_expires' => env('LPL_LOGIN_ROUTE_EXPIRES', 30),
     'redirect_on_success' => env('LPL_REDIRECT_ON_LOGIN', '/'),
     'login_use_once' => env('LPL_USE_ONCE', false),
     'invalid_signature_message' => env('LPL_INVALID_SIGNATURE_MESSAGE', ''),


### PR DESCRIPTION
In Carbon 3 the `login_route_expires` config should return an integer instead of a string.